### PR TITLE
Fix FastScape checkpointing and restarting

### DIFF
--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -75,6 +75,11 @@ namespace aspect
     void fastscape_init_h_(double *hp);
 
     /**
+     * Initialize FastScape silt fraction during a restart.
+     */
+    void fastscape_init_f_(double *sf);
+
+    /**
      * Set FastScape erosional parameters on land. These parameters will apply to the stream power law (SPL)
      * and hillslope diffusion for basement and sediment. This can be set between timesteps.
      */
@@ -135,6 +140,11 @@ namespace aspect
      * Copy the current FastScape basement.
      */
     void fastscape_copy_basement_(double *b);
+
+    /**
+     * Copy the current FastScape silt fraction.
+     */
+    void fastscape_copy_f_(double *sf);
 
     /**
      * Initialize the straigraphy component of FastScape.
@@ -218,7 +228,7 @@ namespace aspect
       /**
        * Function to intialize or restart FastScape
        */
-      void initialize_fastscape(double *h, double *b, double *kd, double *kf) const;
+      void initialize_fastscape(double *h, double *b, double *kd, double *kf, double *sf) const;
 
       /**
        * Execute FastScape
@@ -238,12 +248,12 @@ namespace aspect
       /**
        * Read data from file for restarting.
        */
-      void read_restart_files(double *h, double *b) const;
+      void read_restart_files(double *h, double *b, double *sf) const;
 
       /**
        * Save data to file for restarting.
        */
-      void save_restart_files(const double *h, double *b, int istep) const;
+      void save_restart_files(const double *h, double *b, double *sf, int istep) const;
 
     private:
       /**

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -235,6 +235,16 @@ namespace aspect
        */
       Table<dim,double> fill_data_table(std::vector<double> values, TableIndices<dim> size_idx, int nx, int ny) const;
 
+      /**
+       * Read data from file for restarting.
+       */
+      void read_restart_files(double *h, double *b) const;
+
+      /**
+       * Save data to file for restarting.
+       */
+      void save_restart_files(const double *h, double *b, int istep) const;
+
     private:
       /**
        * First attempt at the number of steps to run FastScape for every ASPECT timestep,

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -142,7 +142,12 @@ namespace aspect
     template <int dim> class World;
   }
 
-  /**
+  namespace TimeStepping
+  {
+    template <int dim> class Manager;
+  }
+
+      /**
    * SimulatorAccess is a base class for different plugins like postprocessors.
    * It provides access to the various variables of the main class that
    * plugins may want to use in their evaluations, such as solution vectors,
@@ -163,8 +168,8 @@ namespace aspect
    *
    * @ingroup Simulator
    */
-  template <int dim>
-  class SimulatorAccess
+      template <int dim>
+      class SimulatorAccess
   {
     public:
       /**
@@ -279,6 +284,14 @@ namespace aspect
        */
       unsigned int
       get_timestep_number () const;
+
+      /**
+       * Return a reference to the manager of the time stepping strategies.
+       * This can then, for example, be check whether a checkpoint needs to
+       * be made upon termination.
+       */
+      const TimeStepping::Manager<dim> &
+      get_timestepping_manager() const;
 
       /**
        * Return the current nonlinear iteration number of a time step.

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -147,29 +147,29 @@ namespace aspect
     template <int dim> class Manager;
   }
 
-      /**
-   * SimulatorAccess is a base class for different plugins like postprocessors.
-   * It provides access to the various variables of the main class that
-   * plugins may want to use in their evaluations, such as solution vectors,
-   * the current time, time step sizes, material models, or the triangulations
-   * and DoFHandlers that correspond to solutions.
-   *
-   * This class is the interface between plugins and the main simulator class.
-   * Using this insulation layer, the plugins need not know anything about the
-   * internal details of the simulation class.
-   *
-   * Every Postprocessor is required to derive from SimulatorAccess. It is
-   * optional for other plugins like MaterialModel, GravityModel, etc..
-   *
-   * Since the functions providing access to details of the simulator class
-   * are meant to be used only by derived classes of this class (rather than
-   * becoming part of the public interface of these classes), the functions of
-   * this class are made @p protected.
-   *
-   * @ingroup Simulator
-   */
-      template <int dim>
-      class SimulatorAccess
+  /**
+  * SimulatorAccess is a base class for different plugins like postprocessors.
+  * It provides access to the various variables of the main class that
+  * plugins may want to use in their evaluations, such as solution vectors,
+  * the current time, time step sizes, material models, or the triangulations
+  * and DoFHandlers that correspond to solutions.
+  *
+  * This class is the interface between plugins and the main simulator class.
+  * Using this insulation layer, the plugins need not know anything about the
+  * internal details of the simulation class.
+  *
+  * Every Postprocessor is required to derive from SimulatorAccess. It is
+  * optional for other plugins like MaterialModel, GravityModel, etc..
+  *
+  * Since the functions providing access to details of the simulator class
+  * are meant to be used only by derived classes of this class (rather than
+  * becoming part of the public interface of these classes), the functions of
+  * this class are made @p protected.
+  *
+  * @ingroup Simulator
+  */
+  template <int dim>
+  class SimulatorAccess
   {
     public:
       /**

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -262,16 +262,6 @@ namespace aspect
           int istep = 0;
           fastscape_get_step_(&istep);
 
-          // Write a file to store h, b & step in case of restart.
-          // TODO: It would be good to roll this into the general ASPECT checkpointing,
-          // and when we do this needs to be changed.
-          if ((this->get_parameters().checkpoint_time_secs == 0) &&
-              (this->get_parameters().checkpoint_steps > 0) &&
-              (current_timestep % this->get_parameters().checkpoint_steps == 0))
-            {
-              save_restart_files(h.get(), b.get(), istep);
-            }
-
           // Set velocity components.
           if (use_velocities)
             {
@@ -285,6 +275,17 @@ namespace aspect
 
           // Find  timestep size, run fastscape, and make visualizations.
           execute_fastscape(h.get(), kd.get(), istep);
+
+          // Write a file to store h, b & step for restarting.
+          // TODO: It would be good to roll this into the general ASPECT checkpointing,
+          // and when we do this needs to be changed.
+            if (((this->get_parameters().checkpoint_time_secs == 0) &&
+                 (this->get_parameters().checkpoint_steps > 0) &&
+                 ((current_timestep + 1) % this->get_parameters().checkpoint_steps == 0)) ||
+                (this->get_time() + a_dt >= end_time && this->get_timestepping_manager().need_checkpoint_on_terminate()))
+            {
+              save_restart_files(h.get(), b.get(), istep);
+            }
 
           // Find out our velocities from the change in height.
           // Where V is a vector of array size that exists on all processes.

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -1066,7 +1066,7 @@ namespace aspect
     template <int dim>
     void FastScape<dim>::read_restart_files(double *h, double *b, double *sf) const
     {
-      this->get_pcout() << "      Loading FastScape restart file... " << std::endl;
+      this->get_pcout() << "   Loading FastScape restart file... " << std::endl;
 
       // Create variables for output directory and restart file
       std::string dirname = this->get_output_directory();
@@ -1114,7 +1114,7 @@ namespace aspect
       if (use_marine && in_sf)
         {
           if (p1 > 0. || p2 > 0.)
-            this->get_pcout() << "  Restarting runs with nonzero porosity can lead to a different system after restart. " << std::endl;
+            this->get_pcout() << "   Restarting runs with nonzero porosity can lead to a different system after restart. " << std::endl;
 
           int line = 0;
 
@@ -1142,7 +1142,7 @@ namespace aspect
     template <int dim>
     void FastScape<dim>::save_restart_files(const double *h, double *b, double *sf, int istep) const
     {
-      this->get_pcout() << "      Writing FastScape restart file... " << std::endl;
+      this->get_pcout() << "   Writing FastScape restart file... " << std::endl;
 
       // Create variables for output directory and restart file
       std::string dirname = this->get_output_directory();

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -288,6 +288,13 @@ namespace aspect
               save_restart_files(h.get(), b.get(), sf.get(), istep);
             }
 
+            // If we've reached the end time, destroy FastScape.
+            if (this->get_time() + this->get_timestep() > end_time)
+            {
+              this->get_pcout() << "      Destroying FastScape..." << std::endl;
+              fastscape_destroy_();
+            }
+
           // Find out our velocities from the change in height.
           // Where V is a vector of array size that exists on all processes.
           for (int i=0; i<array_size; i++)
@@ -621,13 +628,6 @@ namespace aspect
         {
           this->get_pcout() << "      Writing VTK..." << std::endl;
           fastscape_named_vtk_(kd, &vexp, &visualization_step, c, &length);
-        }
-
-      // If we've reached the end time, destroy FastScape.
-      if (this->get_time()+this->get_timestep() > end_time)
-        {
-          this->get_pcout() << "      Destroying FastScape..." << std::endl;
-          fastscape_destroy_();
         }
     }
 

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -148,6 +148,15 @@ namespace aspect
 
 
   template <int dim>
+  const TimeStepping::Manager<dim> &
+  SimulatorAccess<dim>::get_timestepping_manager() const
+  {
+    return simulator->time_stepping_manager;
+  }
+
+
+
+  template <int dim>
   unsigned int SimulatorAccess<dim>::get_nonlinear_iteration () const
   {
     return simulator->nonlinear_iteration;


### PR DESCRIPTION
This PR
* refactors the writing and reading of FastScape files for restarting
* adds the silt_fraction to writing and reading and initializing for restarting models with the marine component on
* aligns when FastScape restart files are created with when ASPECT checkpoints
* moves the writing of restart files to after FastScape has run

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

* [x] I have tested my new feature locally to ensure it is correct.

