### PR TITLE
Melt volatiles profiling and performance optimizations

### DIFF
--- a/conservation_tests/cell.prm
+++ b/conservation_tests/cell.prm
@@ -4,7 +4,7 @@
 # of the ridge.
 
 # plugins has correction, plugins 2 does not.
-set Additional shared libraries = /mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/plugins_noconserve/libvolatile_plugin.release.so
+set Additional shared libraries = ../melt_volatiles_plugins/libvolatile_plugin.so
 set Dimension                              = 2
 set Adiabatic surface temperature          = 1623
 set Resume computation = false

--- a/conservation_tests/free_surface_conserve_test.prm
+++ b/conservation_tests/free_surface_conserve_test.prm
@@ -2,7 +2,7 @@
 # As the flow at mid-ocean ridges can be assumed to be roughly symmetric
 # with respect to the ridge axis in the center, we only model one half
 # of the ridge.
-set Additional shared libraries = /mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/plugin_simon/libvolatile_plugin.release.so
+set Additional shared libraries = ../melt_volatiles_plugins/libvolatile_plugin.so
 
 set Dimension                              = 2
 set Adiabatic surface temperature          = 1623

--- a/conservation_tests/line_test.prm
+++ b/conservation_tests/line_test.prm
@@ -2,7 +2,7 @@
 # As the flow at mid-ocean ridges can be assumed to be roughly symmetric
 # with respect to the ridge axis in the center, we only model one half
 # of the ridge.
-set Additional shared libraries = /mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/plugin_simon/libvolatile_plugin.release.so
+set Additional shared libraries = ../melt_volatiles_plugins/libvolatile_plugin.so
 
 set Dimension                              = 2
 set Adiabatic surface temperature          = 1623

--- a/melt_volatiles_plugins/CMakeLists.txt
+++ b/melt_volatiles_plugins/CMakeLists.txt
@@ -46,10 +46,10 @@ DEAL_II_INITIALIZE_CACHED_VARIABLES()
 SET(TARGET "volatile_plugin")
 PROJECT(${TARGET})
 
-ADD_LIBRARY(${TARGET} SHARED /mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/volatile_concentration.cc 
-/mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/volatiles_melt.cc 
-/mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/melt_simple_volatiles.cc 
-/mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/volatiles_melt_postprocess.cc
-/mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/detailed_flux.cc
+ADD_LIBRARY(${TARGET} SHARED volatile_concentration.cc 
+volatiles_melt.cc 
+melt_simple_volatiles.cc 
+volatiles_melt_postprocess.cc
+detailed_flux.cc
 )
 ASPECT_SETUP_PLUGIN(${TARGET})

--- a/melt_volatiles_plugins/example.prm
+++ b/melt_volatiles_plugins/example.prm
@@ -2,7 +2,7 @@
 # As the flow at mid-ocean ridges can be assumed to be roughly symmetric
 # with respect to the ridge axis in the center, we only model one half
 # of the ridge.
-set Additional shared libraries = /home/bbpdneu1/software/co2/plugins/libvolatile_plugin.release.so
+set Additional shared libraries = ./libvolatile_plugin.release.so
 
 set Dimension                              = 2
 set Adiabatic surface temperature          = 1623

--- a/melt_volatiles_plugins/melt_simple_volatiles.cc
+++ b/melt_volatiles_plugins/melt_simple_volatiles.cc
@@ -23,8 +23,8 @@
 #include <aspect/utilities.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/numerics/fe_field_function.h>
-#include </mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/melt_simple_volatiles.h>
-#include </mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/volatiles_melt.h>
+#include "melt_simple_volatiles.h"
+#include "volatiles_melt.h"
 
 namespace aspect
 {

--- a/melt_volatiles_plugins/melt_simple_volatiles.h
+++ b/melt_volatiles_plugins/melt_simple_volatiles.h
@@ -26,7 +26,7 @@
 #include <aspect/postprocess/melt_statistics.h>
 #include <aspect/melt.h>
 /*#include </Users/djneuh/software/local_code/aspect/melt_volatiles_plugins/volatiles_melt.h>*/
-#include </mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/volatiles_melt.h>
+#include "volatiles_melt.h"
 
 namespace aspect
 {

--- a/melt_volatiles_plugins/volatile_concentration.cc
+++ b/melt_volatiles_plugins/volatile_concentration.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include </mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/volatile_concentration.h>
+#include "volatile_concentration.h"
 #include <aspect/melt.h>
 #include <deal.II/base/parameter_handler.h>
 #include <aspect/simulator.h>

--- a/melt_volatiles_plugins/volatiles_melt.cc
+++ b/melt_volatiles_plugins/volatiles_melt.cc
@@ -338,8 +338,8 @@ template <int dim>
           const double T_solidus = T_solidus_liquidus(pressure, C_bar, true, A, B, L, T0, R);
           const double T_liquidus = T_solidus_liquidus(pressure, C_bar, false, A, B, L, T0, R);
 
-          std::vector<double> Tm = melting_temperatures(pressure, A, B, L, T0);
-          std::vector<double> K = partition_coefficients(pressure, std::max(T_solidus,std::min(T_liquidus,temperature)), A, B, L, T0, R);
+          small_vector<double> Tm = melting_temperatures(pressure, A, B, L, T0);
+          small_vector<double> K = partition_coefficients(pressure, std::max(T_solidus,std::min(T_liquidus,temperature)), A, B, L, T0, R);
           
           // Calculate equilibrium melt fraction.
           Fmass_new = Fmass_old;
@@ -570,7 +570,7 @@ template <int dim>
                           std::vector<double> R) const
       {
         // TODO: Exclude invalid compositions (that do not sum up to 1)?
-        const std::vector<double> Tm = melting_temperatures(pressure, A, B, L, T0);
+        const small_vector<double> Tm = melting_temperatures(pressure, A, B, L, T0);
 
         // Set starting guess for Tsol
         const double minTm = *std::min_element(Tm.begin(), Tm.end());
@@ -588,7 +588,7 @@ template <int dim>
 
         double T_solidus = std::max(minTm, std::min(maxTm, mean_Tm));
 
-        std::vector<double> K = partition_coefficients(pressure, T_solidus, A, B, L, T0, R);
+        small_vector<double> K = partition_coefficients(pressure, T_solidus, A, B, L, T0, R);
 
 const double tolerance = 1e-10;
 const unsigned int max_iterations = 200;
@@ -640,14 +640,14 @@ if (n == max_iterations) {
     }
 
     template <int dim>
-    std::vector<double>
+    small_vector<double>
     VolatilesMelt<dim>::melting_temperatures(const double pressure,
-                                             std::vector<double> A,
-                                             std::vector<double> B,
-                                             std::vector<double> L,
-                                             std::vector<double> T0) const
+                                             const std::vector<double> &A,
+                                             const std::vector<double> &B,
+                                             const std::vector<double> &L,
+                                             const std::vector<double> &T0) const
     {
-        std::vector<double> Tm (n_components);
+        small_vector<double> Tm (n_components);
 
         const double Pmax = 6e9;
         if(use_simons_law)
@@ -678,24 +678,23 @@ if (n == max_iterations) {
 
 
     template <int dim>
-    std::vector<double>
+    small_vector<double>
     VolatilesMelt<dim>::partition_coefficients(const double pressure, 
                                                 const double temperature,
-                                                std::vector<double> A,
-                                                std::vector<double> B,
-                                                std::vector<double> L,
-                                                std::vector<double> T0,
-                                                std::vector<double> R) const
+                                                const std::vector<double> &A,
+                                                const std::vector<double> &B,
+                                                const std::vector<double> &L,
+                                                const std::vector<double> &T0,
+                                                const std::vector<double> &R) const
     {
-        std::vector<double> K (n_components);
-
-        std::vector<double> Tm = melting_temperatures(pressure, A, B, L, T0);
+        small_vector<double> K (n_components);
+        const small_vector<double> Tm = melting_temperatures(pressure, A, B, L, T0);
 
         // Parameterization after Rudge, Bercovici, & Spiegelman (2010)
         for (unsigned int i=0; i<n_components; ++i) 
         {
             // L/T gives the change in entropy.
-            double Ls = L[i]/T0[i]*temperature;
+            const double Ls = L[i]/T0[i]*temperature;
             K[i] = std::exp(Ls/R[i] * (1./temperature - 1./Tm[i]));
         }
 
@@ -704,9 +703,9 @@ if (n == max_iterations) {
 
     template <int dim>
     double 
-    VolatilesMelt<dim>::compute_residual (std::vector<double> composition,
-                      std::vector<double> K,
-                      bool compute_solidus) const
+    VolatilesMelt<dim>::compute_residual (const std::vector<double> &composition,
+                      const small_vector<double> &K,
+                      const bool compute_solidus) const
     {
       double residual = -1.;
       for (unsigned int i=0; i<n_components; ++i) 

--- a/melt_volatiles_plugins/volatiles_melt.cc
+++ b/melt_volatiles_plugins/volatiles_melt.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include </mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/volatiles_melt.h>
+#include "volatiles_melt.h"
 #include <aspect/utilities.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/adiabatic_conditions/interface.h>

--- a/melt_volatiles_plugins/volatiles_melt.h
+++ b/melt_volatiles_plugins/volatiles_melt.h
@@ -67,28 +67,28 @@ namespace aspect
           parse_parameters (ParameterHandler &prm);
 
                     // Calculate melting temperature for each composition.
-          std::vector<double>
+          small_vector<double>
           melting_temperatures(const double pressure,
-                              std::vector<double> A,
-                              std::vector<double> B,
-                              std::vector<double> L,
-                              std::vector<double> T0) const;
+                              const std::vector<double> &A,
+                              const std::vector<double> &B,
+                              const std::vector<double> &L,
+                              const std::vector<double> &T0) const;
 
           // Calculate melting temperature for each composition.
           double
-          compute_residual(std::vector<double> composition,
-                      std::vector<double> K,
-                      bool compute_solidus) const;
+          compute_residual(const std::vector<double> &composition,
+                      const small_vector<double> &K,
+                      const bool compute_solidus) const;
 
           // Calculate melting temperature for each composition.
-          std::vector<double>
+          small_vector<double>
           partition_coefficients(const double pressure,
                                const double temperature,
-                               std::vector<double> A,
-                               std::vector<double> B,
-                               std::vector<double> L,
-                               std::vector<double> T0,
-                               std::vector<double> R) const;
+                               const std::vector<double> &A,
+                               const std::vector<double> &B,
+                               const std::vector<double> &L,
+                               const std::vector<double> &T0,
+                               const std::vector<double> &R) const;
 
           double
           T_solidus_liquidus (const double pressure, 

--- a/melt_volatiles_plugins/volatiles_melt_postprocess.cc
+++ b/melt_volatiles_plugins/volatiles_melt_postprocess.cc
@@ -18,7 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include </mnt/vast-nhr/home/derekjohn.neuharth/u16318/software/co2/aspect/melt_volatiles_plugins/volatiles_melt_postprocess.h>
+#include "volatiles_melt_postprocess.h"
 #include <aspect/melt.h>
 #include <deal.II/base/parameter_handler.h>
 


### PR DESCRIPTION
Here are the optimizations I did.

Valgrind command for running ASPECT with profiling:
```
valgrind --tool=callgrind --cache-sim=yes --branch-sim=yes --dump-instr=yes --collect-jumps=yes --collect-systime=yes --cacheuse=yes "$@"
```

(replace "$@" with aspect executable and parameter file)


Compile flag for deal.II to keep the association of binary and source code:
```
-g
```
e.g. by setting candi configuration to: `DEAL_II_CONFOPTS="-DDEAL_II_CXX_FLAGS='-g'"`

Compile flag for ASPECT:
```
-DASPECT_ADDITIONAL_CXX_FLAGS='-g'
```

Visualization tool: `kcachegrind`


Timos profiling information: https://github.com/tjhei/profiling-demos